### PR TITLE
fix handle_error so that it uses the parsed_response

### DIFF
--- a/lib/unresponsys/client.rb
+++ b/lib/unresponsys/client.rb
@@ -67,16 +67,20 @@ class Unresponsys
     private
 
     def handle_error(response)
-      if response.is_a?(Hash) && response.keys.include?('errorCode')
-        case response['errorCode']
+      # newer versions of httparty response object
+      # do not return true for .is_a?(Hash)
+      # so use the parsed response instead - ckh 12/7/17
+      pres = response.parsed_response
+      if pres.is_a?(Hash) && pres.keys.include?('errorCode')
+        case pres['errorCode']
         when /TOKEN_EXPIRED/
-          raise Unresponsys::TokenExpired, response['detail']
+          raise Unresponsys::TokenExpired, pres['detail']
         when /NOT_FOUND/
-          raise Unresponsys::NotFound, response['detail']
+          raise Unresponsys::NotFound, pres['detail']
         when /LIMIT_EXCEEDED/
-          raise Unresponsys::LimitExceeded, response['detail']
+          raise Unresponsys::LimitExceeded, pres['detail']
         else
-          raise Unresponsys::Error, "#{response['title']}: #{response['detail']}"
+          raise Unresponsys::Error, "#{pres['title']}: #{pres['detail']}"
         end
       end
       response


### PR DESCRIPTION
ran into an issue with httparty and unresponsys gem

in the Client#handle_error method, it expects the HTTParty response object to respond to to `.is_a?(Hash)`.  This works in older versions of HTTParty, but not in  0.15.6.  This bug allows the response to fall through to be handled as if it were a non error response when it should actually raise an exception.

I changed the handle_error method to use the response.parsed_response and the problem is now corrected.

see https://trello.com/c/ZFKajox9/220-bug-3-college-user-approvals-emails-arent-always-sending